### PR TITLE
칭찬 카드 추가

### DIFF
--- a/theDefault/src/main/java/Miyu/actions/ComplimentAction.java
+++ b/theDefault/src/main/java/Miyu/actions/ComplimentAction.java
@@ -1,0 +1,51 @@
+package Miyu.actions;
+
+import Miyu.powers.SelfEsteem;
+import com.megacrit.cardcrawl.actions.AbstractGameAction;
+import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
+import com.megacrit.cardcrawl.cards.DamageInfo;
+import com.megacrit.cardcrawl.characters.AbstractPlayer;
+import com.megacrit.cardcrawl.core.AbstractCreature;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.monsters.AbstractMonster;
+import com.megacrit.cardcrawl.vfx.combat.FlashAtkImgEffect;
+
+public class ComplimentAction extends AbstractGameAction {
+    private int increaseSelfEsteem;
+    private DamageInfo info;
+    private static final float DURATION = 0.1F;
+    private AbstractPlayer p;
+
+    public ComplimentAction(AbstractPlayer player, AbstractCreature target, DamageInfo info, int selfEsteemAmount) {
+        this.p = player;
+        this.info = info;
+        this.setValues(target, info);
+        this.increaseSelfEsteem = selfEsteemAmount;
+        this.actionType = ActionType.DAMAGE;
+        this.duration = 0.1F;
+    }
+
+    public void update() {
+        if (this.duration == 0.1F && this.target != null) {
+            AbstractDungeon.effectList.add(new FlashAtkImgEffect(this.target.hb.cX, this.target.hb.cY, AttackEffect.BLUNT_HEAVY));
+
+            boolean isDamagedOverBlock = isDamagedOverBlock(target);
+
+            this.target.damage(this.info);
+
+            if ((((AbstractMonster)this.target).isDying || this.target.currentHealth <= 0 || isDamagedOverBlock) && !this.target.halfDead && !this.target.hasPower("Minion")) {
+                addToBot(new ApplyPowerAction(p, p, new SelfEsteem(p, p, increaseSelfEsteem), increaseSelfEsteem));
+            }
+
+            if (AbstractDungeon.getCurrRoom().monsters.areMonstersBasicallyDead()) {
+                AbstractDungeon.actionManager.clearPostCombatActions();
+            }
+        }
+
+        this.tickDuration();
+    }
+
+    private Boolean isDamagedOverBlock(AbstractCreature m) {
+        return m.currentBlock > 0 && this.info.output > m.currentBlock;
+    }
+}

--- a/theDefault/src/main/java/Miyu/cards/Compliment.java
+++ b/theDefault/src/main/java/Miyu/cards/Compliment.java
@@ -1,0 +1,69 @@
+package Miyu.cards;
+
+import Miyu.DefaultMod;
+import Miyu.actions.ComplimentAction;
+import Miyu.characters.TheDefault;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.cards.DamageInfo;
+import com.megacrit.cardcrawl.characters.AbstractPlayer;
+import com.megacrit.cardcrawl.monsters.AbstractMonster;
+
+import static Miyu.DefaultMod.makeCardPath;
+
+public class Compliment extends AbstractDynamicCard {
+
+    // TEXT DECLARATION
+
+    public static final String ID = DefaultMod.makeID(Compliment.class.getSimpleName());
+    public static final String IMG = makeCardPath("Dummy.png");
+
+    // /TEXT DECLARATION/
+
+
+    // STAT DECLARATION
+
+    private static final CardRarity RARITY = CardRarity.BASIC;
+    private static final CardTarget TARGET = CardTarget.ENEMY;
+    private static final CardType TYPE = CardType.ATTACK;
+    public static final CardColor COLOR = TheDefault.Enums.COLOR_GRAY;
+
+    private static final int COST = 1;
+
+    private static final int DAMAGE = 8;
+    private static final int UPGRADE_PLUS_DAMAGE = 3;
+
+    private static final int MAGIC = 5;
+
+    // /STAT DECLARATION/
+
+
+    public Compliment() {
+        super(ID, IMG, COST, TYPE, COLOR, RARITY, TARGET);
+        baseDamage = DAMAGE;
+        this.baseMagicNumber = MAGIC;
+    }
+
+    @Override
+    public void use(AbstractPlayer p, AbstractMonster m) {
+        this.calculateCardDamage(m);
+
+        // 칭찬 Action 실행
+        addToBot(
+                new ComplimentAction(p, m, new DamageInfo(p, this.damage, this.damageTypeForTurn), this.baseMagicNumber)
+        );
+    }
+
+    public AbstractCard makeCopy() {
+        return new Compliment();
+    }
+
+    //Upgraded stats.
+    @Override
+    public void upgrade() {
+        if (!upgraded) {
+            upgradeName();
+            upgradeDamage(UPGRADE_PLUS_DAMAGE);
+            initializeDescription();
+        }
+    }
+}

--- a/theDefault/src/main/resources/MiyuResources/localization/kor/DefaultMod-Card-Strings.json
+++ b/theDefault/src/main/resources/MiyuResources/localization/kor/DefaultMod-Card-Strings.json
@@ -230,6 +230,6 @@
   },
   "Miyu:Compliment": {
     "NAME": "칭찬",
-    "DESCRIPTION": " 피해를 !D! 줍니다. NL 적의 방어도를 넘어선 피해를 주거나 처치했다면, Miyu:자존감을 !M! 얻습니다. "
+    "DESCRIPTION": " 피해를 !D! 줍니다. NL 적의 방어도를 넘어선 피해를 주거나 처치했다면, NL Miyu:자존감을 !M! 얻습니다. "
   }
 }

--- a/theDefault/src/main/resources/MiyuResources/localization/kor/DefaultMod-Card-Strings.json
+++ b/theDefault/src/main/resources/MiyuResources/localization/kor/DefaultMod-Card-Strings.json
@@ -227,5 +227,9 @@
   "Miyu:CatCollar": {
     "NAME": "고양이용 목줄",
     "DESCRIPTION": " Miyu:이동할 때마다 NL Miyu:활력을 !M! NL Miyu:자존감을 !Miyu:M2! 얻습니다. "
+  },
+  "Miyu:Compliment": {
+    "NAME": "칭찬",
+    "DESCRIPTION": " 피해를 !D! 줍니다. NL 적의 방어도를 넘어선 피해를 주거나 처치했다면, Miyu:자존감을 !M! 얻습니다. "
   }
 }


### PR DESCRIPTION
1. 적을 처치할 때
2. 방어도를 넘어선 피해를 줬을 때 

둘 다 자존감 잘 올라가는데,
마지막 적이 죽을때는 자존감이 안 올라갑니다. 
어차피 전투 끝나기 때문에 상관 없을 것 같긴 한데 올라가야 정상이라면 코멘트 달아놓으시면 수정해놓을게요

마찬가지로 이미지는 추가해주셔야합니다