### PR TITLE
비밀 장소 카드 수정

### DIFF
--- a/theDefault/src/main/java/Miyu/cards/SecretArea.java
+++ b/theDefault/src/main/java/Miyu/cards/SecretArea.java
@@ -32,15 +32,14 @@ public class SecretArea extends AbstractDynamicCard {
 	public static final CardColor COLOR = TheDefault.Enums.COLOR_GRAY;
 
 	private static final int COST = 1;
-	private static final int BLOCK = 0;
-	private static final int UPGRADE_PLUS_BLOCK = 3;
 	private static final int MAGIC = 0;
+	private static final int UPGRADE_PLUS_MAGIC = 0;
+
 
 	// /STAT DECLARATION/
 
 	public SecretArea() {
 		super(ID, IMG, COST, TYPE, COLOR, RARITY, TARGET);
-		this.baseBlock = BLOCK;
 		this.baseMagicNumber = MAGIC;
 	}
 
@@ -83,6 +82,7 @@ public class SecretArea extends AbstractDynamicCard {
 			addToBot(new ApplyPowerAction(p, p,
 					new Covered(p, p, ((AbstractDynamicCard) c).getCoverMagicNumber(), ((AbstractDynamicCard) c)),
 					((AbstractDynamicCard) c).getCoverMagicNumber()));
+			((ICoverCard) c).triggerOnCovered(p);
 		}
 
 		// 방어도 얻음
@@ -94,8 +94,8 @@ public class SecretArea extends AbstractDynamicCard {
 	public void upgrade() {
 		if (!upgraded) {
 			upgradeName();
-			upgradeBlock(UPGRADE_PLUS_BLOCK);
-			isBlockModified = true;
+			upgradeBlock(UPGRADE_PLUS_MAGIC);
+			isMagicNumberModified = true;
 			initializeDescription();
 		}
 	}


### PR DESCRIPTION
1. 업그레이드 하면 방어도 +3 되는거 정상 표시되도록.
2. 소멸 카드 더미의 엄폐물 카드로 이동 시 해당 엄폐물 카드의 covered 액션 trigger 되도록