### PR TITLE
Urban_S 비용이 깎이는 방식 수정

### DIFF
--- a/theDefault/src/main/java/Miyu/cards/Urban_S.java
+++ b/theDefault/src/main/java/Miyu/cards/Urban_S.java
@@ -13,8 +13,6 @@ import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.localization.CardStrings;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 
-import java.util.Iterator;
-
 import static Miyu.DefaultMod.makeCardPath;
 
 public class Urban_S extends AbstractDynamicCard {
@@ -40,6 +38,8 @@ public class Urban_S extends AbstractDynamicCard {
 
 	private static final int DAMAGE = 5; // DAMAGE = 10
 	private static final int UPGRADE_PLUS_DMG = 2; // UPGRADE_PLUS_DMG = 4
+	
+	private int internalCoverCount = 0;
 
 	// /STAT DECLARATION/
 
@@ -48,21 +48,29 @@ public class Urban_S extends AbstractDynamicCard {
 		this.baseDamage = DAMAGE;
 
 	}
-
-	public void applyPowers() {
-		int count = 0;
-		Iterator var2 = AbstractDungeon.player.hand.group.iterator();
-
-		while (var2.hasNext()) {
-			AbstractCard c = (AbstractCard) var2.next();
-
-			if (c instanceof ICoverCard) {
-				++count;
-			}
-		}
-		this.setCostForTurn(this.cost - count);
-		super.applyPowers();
+	
+	@Override
+	public void triggerWhenDrawn() {
+		super.triggerWhenDrawn();
+		applyPowers();
 	}
+
+	@Override
+	public void applyPowers() {
+		super.applyPowers();
+		updateCost(internalCoverCount - coverCardCounter());
+		internalCoverCount = coverCardCounter();
+	}
+	/*
+	매 순간마다 손에 있는 엄폐물 카드 수의 변화량을 비용에 더합니다
+	만약 이 카드가 손패에 들어왔을 때
+	손에 엄폐물이 2장이라면, 비용에 -2를 더합니다
+	그 상황에서 엄폐물이 1장 없어지면, 비용에 1을 더합니다
+	
+	updateCost(X): 비용에 X만큼 더합니다
+	internalCoverCount: UrbanS 카드들에게 내장시킨 카운터입니다. 처음엔 0입니다
+	coverCardCounter: 손에 있는 엄폐물 카드를 셉니다
+	*/
 
 	@Override
 	public void use(AbstractPlayer p, AbstractMonster m) {
@@ -75,8 +83,41 @@ public class Urban_S extends AbstractDynamicCard {
 				AbstractGameAction.AttackEffect.SLASH_HEAVY));
 	}
 
+	@Override
+	public AbstractCard makeStatEquivalentCopy() {
+		UrbanS copyOfUrbanS = (UrbanS) super.makeStatEquivalentCopy();
+		if (AbstractDungeon.player != null && CardCrawlGame.dungeon != null && AbstractDungeon.currMapNode != null && AbstractDungeon.getCurrRoom().phase == AbstractRoom.RoomPhase.COMBAT) {
+			copyOfUrbanS.internalCoverCount = internalCoverCount;
+		}
+		return copyOfUrbanS;
+	}
+	
+	@Override
 	public AbstractCard makeCopy() {
-		return new Urban_S();
+		UrbanS copy = (UrbanS) super.makeCopy();
+		if (AbstractDungeon.player != null && CardCrawlGame.dungeon != null && AbstractDungeon.currMapNode != null && AbstractDungeon.getCurrRoom().phase == AbstractRoom.RoomPhase.COMBAT) {
+			copy.applyPowers();
+		}
+		return copy;
+	}
+	
+	public int coverCardCounter() {
+		int coverCount = 0;
+		for (AbstractCard card : AbstractDungeon.player.hand.group) {
+			if (c instanceof ICoverCard) {
+				++count;
+			}
+		}
+		return coverCount;
+	}
+	
+	public int thisIsRealUpgradeCost() {
+		int costDifference = UPGRADED_COST - COST;
+		int upgradedCost = cost + costDifference;
+		if (upgradedCost < 0) {
+			upgradedCost = 0;
+		}
+		return upgradedCost;
 	}
 
 	// Upgraded stats.
@@ -85,7 +126,7 @@ public class Urban_S extends AbstractDynamicCard {
 		if (!upgraded) {
 			upgradeName();
 			upgradeDamage(UPGRADE_PLUS_DMG);
-			upgradeBaseCost(UPGRADED_COST);
+			upgradeBaseCost(thisIsRealUpgradeCost());
 			rawDescription = UPGRADE_DESCRIPTION;
 			initializeDescription();
 		}


### PR DESCRIPTION
setCostForTurn() 대신 updateCost() 를 써서 기본 비용을 바꾸도록 했습니다. 이렇게 하면 액상 기억 같은 포션으로 가져와도 비용이 0이 됩니다.