### PR TITLE
도탄 알고리즘 변경 및 버그 수정

### DIFF
--- a/theDefault/src/main/java/Miyu/actions/RicochetAction.java
+++ b/theDefault/src/main/java/Miyu/actions/RicochetAction.java
@@ -5,6 +5,7 @@
 
 package Miyu.actions;
 
+import Miyu.DefaultMod;
 import com.megacrit.cardcrawl.actions.AbstractGameAction;
 import com.megacrit.cardcrawl.actions.animations.VFXAction;
 import com.megacrit.cardcrawl.actions.common.DamageAction;
@@ -14,10 +15,13 @@ import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import com.megacrit.cardcrawl.vfx.combat.ThrowDaggerEffect;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 
 public class RicochetAction extends AbstractGameAction {
+	public static final Logger logger = LogManager.getLogger(DefaultMod.class.getName());
 	private AbstractCard card;
 
 	public RicochetAction(AbstractCard card) {
@@ -47,6 +51,10 @@ public class RicochetAction extends AbstractGameAction {
 		// n번째 위치를 타격한 적이 있는지 저장하는 Boolean Array
 		ArrayList<Boolean> isHit = new ArrayList<>();
 
+		// Logger 출력 대비
+		ArrayList<Integer> hitAttemptHistory = new ArrayList<>();
+		ArrayList<Integer> hitRealHistory = new ArrayList<>();
+
 		// 만약 빈 공간 or 죽은 몬스터가 있던 공간인 경우, 타격한 것으로 처리
 		for (AbstractMonster monster : monsters) {
 			isHit.add(monster.isDeadOrEscaped());
@@ -64,7 +72,13 @@ public class RicochetAction extends AbstractGameAction {
 				// 타겟 위치 마킹 및 타격 가능 여부 확인
 				isHit.set(randomIndex, true);
 				this.target = monsters.get(randomIndex);
-			} while (this.target.isDeadOrEscaped()); // WARNING: 적이 이미 죽은 위치도 타격합니다.
+
+				// Logger 타격 시도 위치 추가
+				hitAttemptHistory.add(randomIndex);
+
+			} while (this.target.isDeadOrEscaped());
+			// Logger 실제 타격 위치 추가
+			hitRealHistory.add(randomIndex);
 
 			// 때림
 			this.card.calculateCardDamage((AbstractMonster) this.target);
@@ -74,6 +88,10 @@ public class RicochetAction extends AbstractGameAction {
 				this.addToBot(new VFXAction(new ThrowDaggerEffect(this.target.hb.cX, this.target.hb.cY)));
 			}
 		}
+
+		// Logger 출력: 타격 시도 위치, 실제 타격 위치
+		logger.info("hitAttemptHistory: " + hitAttemptHistory.toString());
+		logger.info("hitRealHistory: " + hitRealHistory.toString());
 
 		this.isDone = true;
 	}

--- a/theDefault/src/main/java/Miyu/actions/RicochetAction.java
+++ b/theDefault/src/main/java/Miyu/actions/RicochetAction.java
@@ -14,11 +14,8 @@ import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import com.megacrit.cardcrawl.vfx.combat.ThrowDaggerEffect;
-import com.sun.tools.javac.main.Option;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.concurrent.ThreadLocalRandom;
 
 public class RicochetAction extends AbstractGameAction {
 	private AbstractCard card;
@@ -29,34 +26,48 @@ public class RicochetAction extends AbstractGameAction {
 	}
 
 	public void update() {
-		/* 가정: 내 공격턴 중에 몬스터가 분열하거나 위치를 바꾸지 않는다. */
+		/*
+		* 아래 로직은 엄밀히 말하자면, `카드를 시행하면, 그 순간 존재하는 모든 적의 위치를 타격하면 멈춘다.` 에 가깝습니다.
+			* 그래서 아래 가정 2개가 깨질 경우, 버그가 생길 수 있습니다.
+				* 가정 1: 나의 공격 턴 중에 몬스터가 분열하거나 위치를 바꾸지 않는다.
+				* 가정 2: 1개의 도탄 공격이 시행 중이다.
+					* 이 때 도탄 공격에 의해 몬스터가 죽은 경우, 바로 그 자리에 다른 개체가 생성되어 다음 도탄 공격들의 대상이 되지 않는다.
 
-		// 몬스터가 존재할 수 있는 위치를 가져옵니다
+		* 부메랑 칼날, 탄성 플라스크의 적 선택 메커니즘을 사용하지 않은 이유
+			* `AbstractDungeon.getMonsters().getRandomMonster((AbstractMonster)null, true, AbstractDungeon.cardRandomRng);`
+			* 위 함수는 `무작위 적`을 선택하는 함수로서, `특정 적을 때렸는가?`를 파악하기에 적절하지 않습니다.
+
+		* 참고: id 만으로 몇 번째 몬스터인지 파악할 수 없음에 주의하세요.
+			* `fight 4_Byrd` 의 경우, 4개의 섀가 등장하는데,
+				* 이 4개의 섀는 모두 `AbstractMonster.id==Byrd`, `AbstractMonster.name==섀` 값을 가지고 있습니다.
+			* 즉, stringID만 가지고 몇 번째 섀를 골라 낼 수 있는 방법은 아직 제대로 파악하지 못했습니다.
+		*/
+
+
+		// 몬스터가 존재할 수 있는 위치들을 가져옵니다
 		ArrayList<AbstractMonster> monsters = AbstractDungeon.getMonsters().monsters;
 
 		// n번째 위치를 타격한 적이 있는지 저장하는 Boolean Array
 		ArrayList<Boolean> isHit = new ArrayList<>();
 
-		// 만약 빈 공간 or 죽은 몬스터가 있던 공간인 경우, 타격한 적이 있는 것으로 처리
+		// 만약 빈 공간 or 죽은 몬스터가 있던 공간인 경우, 타격한 것으로 처리
 		for (AbstractMonster monster : monsters) {
 			isHit.add(monster.isDeadOrEscaped());
 		}
 
 		// 모든 위치의 몬스터를 타격할 때까지 반복
 		while (isHit.contains(false)) {
+			int randomIndex;
 
 			// 모든 위치 중 랜덤한 숫자를 하나 뽑는다
+			// 단, 그 공간이 빈 공간이거나 죽은 몬스터가 있던 공간이거나 적이 거의 죽어가고 있는 위치인 경우, 다시 숫자를 뽑습니다.
 			do {
-				int randomIndex = ThreadLocalRandom.current().nextInt(0, monsters.size());
+				randomIndex = AbstractDungeon.cardRandomRng.random(0, monsters.size() - 1);
 
-				// 그 위치를 타격할 예정
+				// 타겟 위치 마킹 및 타격 가능 여부 확인
 				isHit.set(randomIndex, true);
-
-				// 타겟 위치 업데이트
 				this.target = monsters.get(randomIndex);
-
-				// 그 공간이 빈 공간이거나 죽은 몬스터가 있던 공간인 경우, 위치를 다시 선택
-			} while (this.target.isDeadOrEscaped());
+			} while (this.target.isDeadOrEscaped()); // WARNING: 적이 이미 죽은 위치도 타격합니다.
 
 			// 때림
 			this.card.calculateCardDamage((AbstractMonster) this.target);

--- a/theDefault/src/main/java/Miyu/actions/RicochetAction.java
+++ b/theDefault/src/main/java/Miyu/actions/RicochetAction.java
@@ -26,23 +26,20 @@ public class RicochetAction extends AbstractGameAction {
 	}
 
 	public void update() {
-		/*
-		* 아래 로직은 엄밀히 말하자면, `카드를 시행하면, 그 순간 존재하는 모든 적의 위치를 타격하면 멈춘다.` 에 가깝습니다.
-			* 그래서 아래 가정 2개가 깨질 경우, 버그가 생길 수 있습니다.
-				* 가정 1: 나의 공격 턴 중에 몬스터가 분열하거나 위치를 바꾸지 않는다.
-				* 가정 2: 1개의 도탄 공격이 시행 중이다.
-					* 이 때 도탄 공격에 의해 몬스터가 죽은 경우, 바로 그 자리에 다른 개체가 생성되어 다음 도탄 공격들의 대상이 되지 않는다.
+		// * 아래 로직은 엄밀히 말하자면, `카드를 시행하면, 그 순간 존재하는 모든 적의 위치를 타격하면 멈춘다.` 에 가깝습니다.
+		// * 그래서 아래 가정 2개가 깨질 경우, 버그가 생길 수 있습니다.
+		// * 가정 1: 나의 공격 턴 중에 몬스터가 분열하거나 위치를 바꾸지 않는다.
+		// * 가정 2: 1개의 도탄 공격이 시행 중일 때 몬스터가 죽은 경우, 바로 그 자리에 다른 개체가 생성되어 다음 도탄 공격들의 대상이 되지 않는다.
 
-		* 부메랑 칼날, 탄성 플라스크의 적 선택 메커니즘을 사용하지 않은 이유
-			* `AbstractDungeon.getMonsters().getRandomMonster((AbstractMonster)null, true, AbstractDungeon.cardRandomRng);`
-			* 위 함수는 `무작위 적`을 선택하는 함수로서, `특정 적을 때렸는가?`를 파악하기에 적절하지 않습니다.
+		// * 부메랑 칼날, 탄성 플라스크의 적 선택 메커니즘을 사용하지 않은 이유
+		// * `AbstractDungeon.getMonsters().getRandomMonster((AbstractMonster)null, true,
+		// AbstractDungeon.cardRandomRng);`
+		// * 위 함수는 `무작위 적`을 선택하는 함수로서, `특정 적을 때렸는가?`를 파악하기에 적절하지 않습니다.
 
-		* 참고: id 만으로 몇 번째 몬스터인지 파악할 수 없음에 주의하세요.
-			* `fight 4_Byrd` 의 경우, 4개의 섀가 등장하는데,
-				* 이 4개의 섀는 모두 `AbstractMonster.id==Byrd`, `AbstractMonster.name==섀` 값을 가지고 있습니다.
-			* 즉, stringID만 가지고 몇 번째 섀를 골라 낼 수 있는 방법은 아직 제대로 파악하지 못했습니다.
-		*/
-
+		// * 참고: id 만으로 몇 번째 몬스터인지 파악할 수 없음에 주의하세요.
+		// * `fight 4_Byrd` 의 경우, 4개의 섀가 등장하는데,
+		// * 이 4개의 섀는 모두 `AbstractMonster.id==Byrd`, `AbstractMonster.name==섀` 값을 가지고 있습니다.
+		// * 즉, stringID만 가지고 몇 번째 섀를 골라 낼 수 있는 방법은 아직 제대로 파악하지 못했습니다.
 
 		// 몬스터가 존재할 수 있는 위치들을 가져옵니다
 		ArrayList<AbstractMonster> monsters = AbstractDungeon.getMonsters().monsters;

--- a/theDefault/src/main/java/Miyu/actions/RicochetAction.java
+++ b/theDefault/src/main/java/Miyu/actions/RicochetAction.java
@@ -60,7 +60,7 @@ public class RicochetAction extends AbstractGameAction {
 
 			// 때림
 			this.card.calculateCardDamage((AbstractMonster) this.target);
-			this.addToTop(new DamageAction(this.target,
+			this.addToBot(new DamageAction(this.target,
 					new DamageInfo(AbstractDungeon.player, this.card.damage, this.card.damageTypeForTurn)));
 			if (this.target != null && this.target.hb != null) {
 				this.addToBot(new VFXAction(new ThrowDaggerEffect(this.target.hb.cX, this.target.hb.cY)));


### PR DESCRIPTION
## PR 개요
Issue #24 이슈를 해결하기 위한 PR입니다.

## 수정 내역
1. `addToTop(..)` -> `addToBot(..)`: 실제 데미지 부여 순서가 역순으로 들어가던 현상을 수정합니다.
    * 예로 들어 실제 적 선택은 `1, 3, 3, 3, 2` 로 선택했다고 하면
        * 예전에는 `addToTop(..)` 으로 ActionQueue 앞쪽에 push하게 되어, 적 공격 시 역순으로 `2, 3, 3, 3, 1` 실행
    * 그래서 이를 수정하였음.
    * ActionQueue에 대한 자세한 설명은 BaseMod의 상위 디렉토리인 BasicMod의 다음 위키 문서를 참조하세요.
        * [Auction-Queue in BaseMod](https://github.com/Alchyr/BasicMod/wiki/Action-Queue)


3. 아직 해결하지 못한 것
    * 600f64e6f6a006f40b0ead4b94ab5ffbc962ea35 커밋 상태에서 발견한 버?그
        * 여러 적이 등장하는 경우, 이미 죽은 적은 타겟으로 삼는 경우가 있음
            *  이 경우에는 데미지가 들어가진 않지만, `ThrowDaggerEffect`가 부여되는 현상이 발견됨.
            *  적이 죽더라도, 위치 포지션이 변경되는 것은 아닌 것으로 보임.
        * 이 경우, 도탄으로 인해 추가적인 데미지를 부여하는 상황이 발생할 수 있음.
            * 가정 -> 적 1, 2번 Live, 3번 Dead 인 경우, 도탄 적 선택 순서가 1, 2, 1, 2, 1, 2, 1, 2 ...를 반복하는 경우가 발생할 수 있음.
              * 이 오류는 이후 커밋을 통해 수정 예정 
    * 공격 랜덤 고정(시드에 따라 랜덤 선택 고정시키기)